### PR TITLE
Update context.py

### DIFF
--- a/spello/context/context.py
+++ b/spello/context/context.py
@@ -159,7 +159,6 @@ class ContextModel(object):
                 memory[-1].append(memory_item)
             memory = memory[1:]
 
-        print(len(memory[-1][0].decoded))
         decoded = ' '.join([suggestions[t][i] for t, i in enumerate(memory[-1][0].decoded[-sent_word_count:],
                                                                     start=2)])
         # score = memory[-1][0].score

--- a/spello/model.py
+++ b/spello/model.py
@@ -243,7 +243,8 @@ class SpellCorrectionModel(object):
             }
 
             suggestions_dict = {}
-            clean_text = get_clean_text(text)
+#             clean_text = get_clean_text(text)
+            clean_text = text
             tokens = clean_text.split()
             for token in tokens:
                 lowercase_token = token.lower()


### PR DESCRIPTION
Removing debug print from context model correction.

Whenever a sentence is spell-corrected, that print would be activated. If you are doing a huge amount of corrections, chances are your logs will be clogged with these numbers.